### PR TITLE
Upload artifacts created by builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,3 +20,23 @@ jobs:
 
     - name: Build
       run:  script/cibuild
+
+    - name: Set up FPM
+      run:  |
+        sudo apt-get install ruby ruby-dev rubygems build-essential
+        sudo gem install --no-document fpm
+
+    - name: Build artifacts
+      run:  |
+        export GOPATH="$PWD/.gopath"
+        cd .gopath/src/github.com/github/orchestrator
+        ./build.sh
+
+        mkdir -p /tmp/packages
+        mv /tmp/orchestrator-release/*.deb /tmp/packages
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: packages
+        path: /tmp/packages


### PR DESCRIPTION
In order to have a consistent setup for creating artifacts and facilitate easier deployment of these artifacts, upload artifacts created by the build via github actions.

You can see these in https://github.com/PagerDuty/orchestrator/runs/378331258 (ie: checks tab above) on the top right